### PR TITLE
Changed word to be written in full

### DIFF
--- a/beanstalktop.py
+++ b/beanstalktop.py
@@ -135,7 +135,7 @@ class BeanstalkTopUI(object):
             'Cur. Ready: {current-jobs-ready}',
             'Cur. Urgent: {current-jobs-urgent}',
             'Cur. Buried: {current-jobs-buried}',
-            'Cur. Resv\'d: {current-jobs-reserved}',
+            'Cur. Reserved: {current-jobs-reserved}',
             )]
 
         summary_lines = [


### PR DESCRIPTION
This is a matter of opinion but I think it looks better to write the word in full. You're only saving one character by abbreviating and it doesn't look better.