### PR TITLE
Move beanstalktop.py into site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 import os
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as file_readme:
@@ -15,8 +15,7 @@ setup(name="beanstalktop",
               'beanstalktop = beanstalktop:main',
               ],
           },
-      scripts=['beanstalktop.py', ],
-      packages=find_packages(),
+      py_modules=['beanstalktop'],
       install_requires=[
           'beanstalkc',
           'PyYAML',


### PR DESCRIPTION
I noticed that `beanstalktop.py` was being put in the `bin/` folder with `beanstalktop` and it is working because when `beanstalktop` imports `beanstalktop.py` it checks its parent directory.

This PR will move beanstalktop.py into `site-packages/`.

`bin/beanstalktop` used to be 

```Python
#!/home/siecje/venv/bin/python3

# -*- coding: utf-8 -*-
import re
import sys

from beanstalktop import main

if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

and it will become

```Python
#!/home/siecje/venv/bin/python3
# EASY-INSTALL-ENTRY-SCRIPT: 'beanstalktop==0.0.4','console_scripts','beanstalktop'
__requires__ = 'beanstalktop==0.0.4'
import re
import sys
from pkg_resources import load_entry_point

if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
    sys.exit(
        load_entry_point('beanstalktop==0.0.4', 'console_scripts', 'beanstalktop')()
    )
```